### PR TITLE
feat: add DELETE /booking/{id} endpoint for admin booking cancellation

### DIFF
--- a/app/api/routes/booking_router.py
+++ b/app/api/routes/booking_router.py
@@ -116,6 +116,18 @@ def update_booking(
         raise HTTPException(status_code=404, detail=str(e))
 
 
+@router.delete("/booking/{booking_id}", status_code=204)
+def delete_booking(
+    booking_id: int,
+    booking_service: BookingService = Depends(get_booking_service),
+    current_admin = Depends(get_current_admin)
+):
+    try:
+        booking_service.delete_booking(booking_id)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+
 @router.patch("/booking/{booking_id}/confirm", response_model=BookingResponse)
 def confirm_booking(
     booking_id: int, 

--- a/app/models.py
+++ b/app/models.py
@@ -3,7 +3,7 @@ import secrets
 from enum import Enum
 
 from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Integer, String, Float, Text, Enum as SQLEnum, CheckConstraint
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, backref
 
 from app.database import Base
 
@@ -74,9 +74,9 @@ class Booking(Base):
     )
 
     guest = relationship("Guest", back_populates="bookings")
-    meter_readings = relationship("MeterReading", back_populates="booking", uselist=False)
-    payments = relationship("Payment", back_populates="booking")
-    invoice_snapshot = relationship("InvoiceSnapshot", back_populates="booking", uselist=False)
+    meter_readings = relationship("MeterReading", back_populates="booking", uselist=False, cascade="all, delete-orphan")
+    payments = relationship("Payment", back_populates="booking", cascade="all, delete-orphan")
+    invoice_snapshot = relationship("InvoiceSnapshot", back_populates="booking", uselist=False, cascade="all, delete-orphan")
 
 
 class BookingToken(Base):
@@ -90,7 +90,7 @@ class BookingToken(Base):
     last_used_at = Column(DateTime, nullable=True)
     
     # Relationship
-    booking = relationship("Booking", backref="tokens")
+    booking = relationship("Booking", backref=backref("tokens", cascade="all, delete-orphan"))
 
 
 class Guest(Base):

--- a/app/services/booking_service.py
+++ b/app/services/booking_service.py
@@ -246,6 +246,12 @@ class BookingService:
         
         db.commit()
 
+    def delete_booking(self, booking_id: int) -> None:
+        booking = self.booking_repository.get_by_id(booking_id)
+        if not booking:
+            raise ValueError(f"Booking with ID {booking_id} not found")
+        self.booking_repository.delete(booking)
+
     def check_and_confirm_bookings(self, auto_confirm_delay_hours: int = 36) -> int:
         """Check for bookings that need automatic confirmation."""
         from datetime import datetime, timedelta


### PR DESCRIPTION
- Add cascade="all, delete-orphan" to Booking relationships (meter_readings, payments, invoice_snapshot, tokens) so child records are removed automatically
- Add delete_booking() to BookingService
- Register DELETE /booking/{booking_id} route (admin-only, returns 204/404)